### PR TITLE
Update Image Tag in Helm Chart

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: codeclimate/velocity-agent
   pullPolicy: Always
-  tag: "latest-v2"
+  tag: "latest"
 
 resources:
   limits:


### PR DESCRIPTION
# Update Image Tag in Helm Chart

## Purpose
The purpose of this change is to update the Docker image tag reference in our Helm chart to ensure our deployments are using the latest available image.

## Description
This pull request includes a single change in the `values.yaml` file where the image tag is modified from `latest-v2` to `latest`. The `latest-v2` tag was previously used for images tied to Ruby 2.x. As we move forward, we will be using the `latest` tag, which should refer to the newest version of our image, allowing us to keep our application up-to-date with the latest features and security patches.

The change summary is as follows:

```diff
diff --git a/values.yaml b/values.yaml
index cae24b5..0fe89e2 100644
--- a/values.yaml
+++ b/values.yaml
@@ -6 +6 @@ image:
-  tag: "latest-v2"
+  tag: "latest"
```

This reflects our efforts to streamline our image tagging process and ensure our deployments are based on the most current and stable releases.
